### PR TITLE
Update invoices-per-country.sql

### DIFF
--- a/invoices-per-country.sql
+++ b/invoices-per-country.sql
@@ -1,5 +1,16 @@
-SELECT co.country_name, count(*), AVG(i.total_price)
-FROM country co, city ci, customer cu, invoice i
-WHERE co.id = ci.country_id AND ci.id = cu.city_id AND cu.id = i.customer_id
-GROUP BY co.country name
-HAVING AVG(i.total_price) > (SELECT AVG(total price))
+SELECT 
+    co.country_name, 
+    COUNT(*) AS customer_count, 
+    AVG(i.total_price) AS avg_total_price
+FROM 
+    country co
+JOIN 
+    city ci ON co.id = ci.country_id
+JOIN 
+    customer cu ON ci.id = cu.city_id
+JOIN 
+    invoice i ON cu.id = i.customer_id
+GROUP BY 
+    co.country_name
+HAVING 
+    AVG(i.total_price) > (SELECT AVG(total_price) FROM invoice);


### PR DESCRIPTION
The previous code was changed to fix syntax errors (e.g., country name to country_name), clarify the HAVING subquery  by specifying the table (`FROM invoice`), and replace outdated implicit joins with modern explicit JOINs  for better readability and performance. These changes ensure the query runs correctly and adheres to SQL best practices.